### PR TITLE
change to use $id because $number is empty

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -32,7 +32,7 @@ info "id: $id"
 info "url: $url"
 
 result=`curl -s \
-  --data-urlencode "source=Project $WERCKER_APPLICATION_NAME $step $number, $url: $status" \
+  --data-urlencode "source=Project $WERCKER_APPLICATION_NAME $step $id, $url: $status" \
   --data "format=html" \
   "https://idobata.io/hook/$WERCKER_IDOBATA_NOTIFY_TOKEN" \
   --output "$WERCKER_STEP_TEMP/result.txt" \


### PR DESCRIPTION
Hi, thank you for nice plugin.

In the file `run.sh`, `$number` is not declared but it is used in `--data-urlencode` parameter.
In contrast, `$id` is declared but it is not used anywhere without logging. So I think it is not `$number` but `$id`.
